### PR TITLE
Order show permissions and photo error fix

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -22,6 +22,11 @@ class OrdersController < ApplicationController
   def show
     @order = Order.find_by(id: params[:order_id])
 
+    if !@auth_user || @auth_user.id != params[:merchant_id].to_i
+      flash[:status] = :failure
+      flash[:message] = "Cannot view order if you're not the authorized owner"
+      return redirect_to products_path
+    end
     # case for cart
     # case for merchant checking their orders they bought
     # case for merchant checking orders from people who bought from them
@@ -29,9 +34,6 @@ class OrdersController < ApplicationController
 
   def cart
     @order = Order.find_by(id: session[:order_id])
-    if @order
-      @order_items = @order.order_items.order(:id)
-    end
   end
 
   private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -48,4 +48,21 @@ module ApplicationHelper
   def potato
     return "https://vignette1.wikia.nocookie.net/adventuretimewithfinnandjake/images/9/93/Potato-potato.jpg/revision/latest?cb=20120411031630"
   end
+
+  def uri?(string)
+    uri = URI.parse(string)
+    %w( http https ).include?(uri.scheme)
+  rescue URI::BadURIError
+    false
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def asset_exist?(path)
+    if Rails.configuration.assets.compile
+      Rails.application.precompiled_assets.include? path
+    else
+      Rails.application.assets_manifest.assets[path].present?
+    end
+  end
 end

--- a/app/views/orders/cart.html.erb
+++ b/app/views/orders/cart.html.erb
@@ -15,13 +15,13 @@ session[:user_id] = <%= session[:user_id] %>
 <hr>
 <hr>
 
-<% if @order == nil || @order_items.length == 0%>
+<% if @order == nil || @order.order_items.length == 0 %>
   <h3>You have nothing in your cart!</h3>
   <p>Please add something to your cart!</p>
   <%= link_to("See All Our Products", products_path, class: "button") %>
 <% else %>
-  <p>Order Item Count: <%= @order_items.count %></p>
-  <% @order_items.each do |item| %>
+  <p>Order Item Count: <%= @order.order_items.count %></p>
+  <% @order.order_items.each do |item| %>
   <p>DEBUG:
   order_item id = <%= item.id %>
   product id = <%= item.product.id %>

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -7,7 +7,7 @@
 
   <div class="large-4 medium-6 small-12 columns end" id="product-container">
     <article class="product">
-      <% if product.photo_url %>
+      <% if product.photo_url && (uri?(product.photo_url) || asset_exist?(product.photo_url)) %>
         <%= image_tag product.photo_url, alt: product.name, class: "thumbnail product-photo", align: "right"  %>
       <% end %>
       <h2><%= link_to(product.name, product_path(product.id)) %></h2>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,7 +24,7 @@
   </div>
 
   <div class="large-6 columns">
-    <% if @product.photo_url %>
+    <% if @product.photo_url && (uri?(product.photo_url) || asset_exist?(product.photo_url)) %>
       <%= link_to image_tag @product.photo_url, alt: 'link to', class: "product" %>
     <% end %>
   </div>


### PR DESCRIPTION
- attempted the retrieving logged-in user's old cart logic, gave up 😢
- fixed Order#show permissions where a guest user or a non-owner merchant can't view the orders another merchant is fulfilling
- fixed photo_url logic so that non-existing assets/invalid URLs don't show